### PR TITLE
[Bug#25]

### DIFF
--- a/Survey-Nimble/Screens/Home/HomeViewController.swift
+++ b/Survey-Nimble/Screens/Home/HomeViewController.swift
@@ -333,6 +333,13 @@ extension HomeViewController {
 
 extension HomeViewController: UICollectionViewDelegate {
     
+    func scrollViewDidScroll(_ scrollView: UIScrollView) {
+        let offsetX = scrollView.contentOffset.x
+        let width = scrollView.frame.size.width
+        
+        pageControl.currentPage = Int(offsetX) / Int(width)
+    }
+    
     func scrollViewDidEndDecelerating(_ scrollView: UIScrollView) {
         let offsetX = scrollView.contentOffset.x
         let contentWidth = scrollView.contentSize.width
@@ -346,8 +353,6 @@ extension HomeViewController: UICollectionViewDelegate {
             page += 1
             loadTrigger.onNext(page)
         }
-        
-        pageControl.currentPage = Int(offsetX) / Int(width)
     }
 }
 


### PR DESCRIPTION
## What is this PR do ?

- put pageControl calculation into didScroll function to get timely page indicator when scrolling

## Root cause
- https://github.com/nkhanh44/Survey_Nimble/issues/25 
- put pageControl calculation  into scrollViewDidEndDecelerating function

## POW

https://drive.google.com/file/d/1Mb0q6fFpLf3mrMoJZ2tk7T-S8Ux6YJNu/view?usp=sharing